### PR TITLE
Set default value to development

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = process.env.NODE_ENV
+module.exports = process.env.NODE_ENV || 'development'


### PR DESCRIPTION
To avoid tedious nodeEnv || 'development' calls